### PR TITLE
Correct the Gallery class in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ export default class Gallery {
     this._selectedImage = 0
   }
 
-  nextImage() {
+  nextImage = () => {
     if (this._selectedImage < this.images.length - 1) {
       this._selectedImage++
     }
   }
 
-  previousImage() {
+  previousImage = () => {
     if (this._selectedImage > 0) {
       this._selectedImage--
     }
   }
 
-  addImage(image) {
+  addImage = (image) => {
     this._images.push(image)
   }
 
-  currentImage() {
+  currentImage = () => {
     return this._images[this._selectedImage]
   }
 }


### PR DESCRIPTION
The example throws the error when we click "Previous Image".
The problem was with missing context and to avoid it we can use class properties/arrow functions.